### PR TITLE
Update react and react-dom peerDependencies format

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "sinon": "^1.17.3"
   },
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "ava": {
     "babel": {


### PR DESCRIPTION
This is more consistent with how other libraries manage the version in `peerDependencies` and I believe will be more considerate of the parent package's `react` version. Unsure we even need `react-dom` here but I'll leave it for now.
