### PR TITLE
Fix: Incorrect property name check

### DIFF
--- a/src/ElementPortal.js
+++ b/src/ElementPortal.js
@@ -5,7 +5,7 @@ const reDataAttr = /^data\-(.+)$/;
 
 export const getNodeData = (node) => {
   // fallback
-  if (!node.datset) {
+  if (!node.dataset) {
     const result = {};
     const attributes = node.attributes;
     for (let i = 0; i < attributes.length; i++) {


### PR DESCRIPTION
Incorrect `datset` property name resulted in fallback branch being always executed.