### PR TITLE
Update component propType to elementType

### DIFF
--- a/src/ElementPortal.js
+++ b/src/ElementPortal.js
@@ -38,7 +38,7 @@ const ElementPortal = createReactClass({
       PropTypes.instanceOf(NodeList),
       PropTypes.arrayOf(PropTypes.instanceOf(HTMLElement))
     ]),
-    component: PropTypes.func,
+    component: PropTypes.elementType,
     mapNodeToProps: PropTypes.func,
     resetAttributes: PropTypes.oneOfType([
       PropTypes.bool,


### PR DESCRIPTION
Since React v16.6, a React element can be an object or function. We should use `elementType` to prevent warning messages in the console.

See [these release notes](https://github.com/reduxjs/react-redux/releases/tag/v7.0.1) for more information.